### PR TITLE
自動更新実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -68,8 +68,6 @@ $(function(){
     if (window.location.href.match(/\/groups\/\d+\/messages/)){//今いるページのリンクが/groups/グループID/messagesのパスとマッチすれば以下を実行。
       var last_message_id = $('.message:last').data("id"); //dataメソッドで.messageにある:last最後のカスタムデータ属性を取得しlast_message_idに代入。
       // var group_id = $(".group").data("group-id");
-     console.log(last_message_id)
-     console.log($('.message:last')[0])
       $.ajax({ //ajax通信で以下のことを行う
         url: "api/messages", //サーバを指定。今回はapi/message_controllerに処理を飛ばす
         type: 'get', //メソッドを指定

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -9,7 +9,7 @@ $(function(){
            </div>
         <div class="upper-message__date">${message.date}
       </div>
-</div>
+       </div>
       <div class="lower-message">
          <p class="lower-message__content">${message.content}
          </p>
@@ -35,6 +35,7 @@ $(function(){
     }
       return html
   }
+
   $('#new_message').on('submit', function(e){
     e.preventDefault();
     var formData = new FormData(this);
@@ -62,4 +63,33 @@ $(function(){
       $('.form__submit').prop('disabled', false);
     });
   })
+  var reloadMessages = function () {
+    
+    if (window.location.href.match(/\/groups\/\d+\/messages/)){//今いるページのリンクが/groups/グループID/messagesのパスとマッチすれば以下を実行。
+      var last_message_id = $('.message:last').data("message-id"); //dataメソッドで.messageにある:last最後のカスタムデータ属性を取得しlast_message_idに代入。
+      // var group_id = $(".group").data("group-id");
+
+      $.ajax({ //ajax通信で以下のことを行う
+        url: "api/messages", //サーバを指定。今回はapi/message_controllerに処理を飛ばす
+        type: 'get', //メソッドを指定
+        dataType: 'json', //データはjson形式
+        data: {last_id: last_message_id} //飛ばすデータは先ほど取得したlast_message_id。またparamsとして渡すためlast_idとする。
+      })
+      .done(function (messages) { //通信成功したら、controllerから受け取ったデータ（messages)を引数にとって以下のことを行う
+        var insertHTML = '';//追加するHTMLの入れ物を作る
+        messages.forEach(function (message) {//配列messagesの中身一つ一つを取り出し、HTMLに変換したものを入れ物に足し合わせる
+          insertHTML = buildHTML(message); //メッセージが入ったHTMLを取得
+          $('.messages').append(insertHTML);//メッセージを追加
+        })
+        $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');//最新のメッセージが一番下に表示されようにスクロールする。
+      })
+      .fail(function () {
+        alert('自動更新に失敗しました');//ダメだったらアラートを出す
+      });
+    }
+  };
+  setInterval(reloadMessages, 7000);//7000ミリ秒ごとにreloadMessagesという関数を実行し自動更新を行う。
 });
+
+  
+

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -2,7 +2,7 @@ $(function(){
   function buildHTML(message){
     // 「もしメッセージに画像が含まれていたら」という条件式
     if (message.image) {
-      var html = `<div class="message">
+      var html = `<div class="message" data-id="${message.id}" >
       
       <div class="upper-message">
         <div class="upper-message__user-name">${message.user_name}
@@ -66,9 +66,10 @@ $(function(){
   var reloadMessages = function () {
     
     if (window.location.href.match(/\/groups\/\d+\/messages/)){//今いるページのリンクが/groups/グループID/messagesのパスとマッチすれば以下を実行。
-      var last_message_id = $('.message:last').data("message-id"); //dataメソッドで.messageにある:last最後のカスタムデータ属性を取得しlast_message_idに代入。
+      var last_message_id = $('.message:last').data("id"); //dataメソッドで.messageにある:last最後のカスタムデータ属性を取得しlast_message_idに代入。
       // var group_id = $(".group").data("group-id");
-
+     console.log(last_message_id)
+     console.log($('.message:last')[0])
       $.ajax({ //ajax通信で以下のことを行う
         url: "api/messages", //サーバを指定。今回はapi/message_controllerに処理を飛ばす
         type: 'get', //メソッドを指定

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,12 @@
+class Api::MessagesController < ApplicationController
+  def index
+    # ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得する
+    group = Group.find(params[:group_id])
+    # ajaxで送られてくる最後のメッセージのid番号を変数に代入
+    last_message_id = params[:id].to_i
+    # 取得したグループでのメッセージ達から、idがlast_message_idよりも新しい(大きい)メッセージ達のみを取得
+    @messages = group.messages.includes(:user).where("id > #{last_message_id}")
+  end
+end
+
+

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -3,7 +3,7 @@ class Api::MessagesController < ApplicationController
     # ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得する
     group = Group.find(params[:group_id])
     # ajaxで送られてくる最後のメッセージのid番号を変数に代入
-    last_message_id = params[:id].to_i
+    last_message_id = params[:last_id].to_i
     # 取得したグループでのメッセージ達から、idがlast_message_idよりも新しい(大きい)メッセージ達のみを取得
     @messages = group.messages.includes(:user).where("id > #{last_message_id}")
   end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: {id: message.id}}
   .upper-message
     .upper-message__user-name
       = message.user.name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,9 @@ Rails.application.routes.draw do
   root 'groups#index'
   resources :users, only: [:edit, :update, :index]
   resources :groups, only: [:new, :create, :edit, :update] do
-  resources :messages, only: [:index, :create]
-   end
+    resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
+end


### PR DESCRIPTION
＃why
今でも自分が投稿した場合は、非同期で画面に表示されます。しかし、別のユーザーの投稿メッセージはリロードしなければ表示されません。これではチャットとは言えないので、自動でチャット画面が更新されるようにしましょう。

＃What
あるユーザーが「メッセージ３」を投稿したら他のユーザーのブラウザにリロードなしでそのメッセージが表示されるようにすることです。

